### PR TITLE
fix the link to the HelmRelease CRD file

### DIFF
--- a/services/helmfile.yaml
+++ b/services/helmfile.yaml
@@ -42,4 +42,4 @@ releases:
     - events: ["presync"]
       showlogs: true
       command: "/bin/sh"
-      args: ["-c", "kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/flux-helm-release-crd.yaml"]
+      args: ["-c", "kubectl apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/crds.yaml"]


### PR DESCRIPTION
This PR addresses the change in HelmRelease CRD yaml location in the github.com/fluxcd/helm-operator repository.

Resolves #1 